### PR TITLE
Add Cromwell commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # altocumulus
 
-Command line utilities for running workflows on [Terra](https://app.terra.bio/) or [CromWell](https://github.com/broadinstitute/cromwell) including:
+Command line utilities for running workflows on [Terra](https://app.terra.bio/) or [Cromwell](https://github.com/broadinstitute/cromwell) including:
 
 - Run a Terra method. Replace local file paths with workspace Google Cloud bucket URLs. Automatically
     upload referenced files to workspace Google bucket.
@@ -17,7 +17,7 @@ Re: useful links:
 
 ## Installation
 
-    git clone https://github.com/klarman-cell-observatory/altocumulus.git
+    git clone https://github.com/lilab-bcb/altocumulus.git
     cd altocumulus
     pip install -e .
 

--- a/alto/__main__.py
+++ b/alto/__main__.py
@@ -1,13 +1,17 @@
 import sys
 import argparse
-from alto.commands import terra, upload, parse_monitoring_log
+from alto.commands import terra, upload, parse_monitoring_log, cromwell
+
+import requests
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
+requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 def main():
-    str2module = {'terra': terra, 'upload': upload, 'parse_monitoring_log': parse_monitoring_log}
+    str2module = {'terra': terra, 'upload': upload, 'parse_monitoring_log': parse_monitoring_log, 'cromwell': cromwell}
 
     parser = argparse.ArgumentParser(description='Run an altocumulus command.')
-    parser.add_argument('command', help='The command', choices=['terra', 'upload', 'parse_monitoring_log'])
+    parser.add_argument('command', help='The command', choices=['terra', 'upload', 'parse_monitoring_log', 'cromwell'])
     parser.add_argument('command_args', help='The command arguments', nargs=argparse.REMAINDER)
     my_args = parser.parse_args()
 

--- a/alto/commands/cromwell/__init__.py
+++ b/alto/commands/cromwell/__init__.py
@@ -1,0 +1,14 @@
+import sys, argparse
+from . import run, check_status
+
+def main(args):
+    str2module = {'run': run, 'check_status': check_status}
+
+    parser = argparse.ArgumentParser(description='Run a terra sub-command.')
+    parser.add_argument('subcommand', help='The sub-command', choices=['run', 'check_status'])
+    parser.add_argument('subcommand_args', help='The sub-command arguments', nargs=argparse.REMAINDER)
+    my_args = parser.parse_args(args)
+
+    subcmd = str2module[my_args.subcommand]
+    sys.argv[0] = f'alto cromwell {my_args.subcommand}'
+    subcmd.main(my_args.subcommand_args)

--- a/alto/commands/cromwell/check_status.py
+++ b/alto/commands/cromwell/check_status.py
@@ -1,0 +1,32 @@
+import argparse, requests
+
+
+def get_status(server, port, job_id, no_ssl_verify):
+    resp = requests.get(f"http://{server}:{port}/api/workflows/v1/{job_id}/status", verify=not no_ssl_verify)
+    resp_dict = resp.json()
+
+    if resp.status_code == 200:
+        print(f"Job {resp_dict['id']} is in status {resp_dict['status']}.")
+    else:
+        print(resp_dict['message'])
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Check the current status for a workflow on a Cromwell server."
+    )
+    parser.add_argument('-s', '--server', dest='server', action='store', required=True,
+        help="Server hostname or IP address."
+    )
+    parser.add_argument('-p', '--port', dest='port', action='store', default='8000',
+        help="Port number for Cromwell service. The default port is 8000."
+    )
+    parser.add_argument('--id', dest='job_id', action='store', required=True,
+        help="Workflow ID returned in 'alto cromwell run' command."
+    )
+    parser.add_argument('--no-ssl-verify', dest='no_ssl_verify', action='store_true', default=False,
+        help="Disable SSL verification for web requests. Not recommended for general usage, but can be useful for intra-networks which don't support SSL verification."
+    )
+
+    args = parser.parse_args(argv)
+
+    get_status(args.server, args.port, args.job_id, args.no_ssl_verify)

--- a/alto/commands/cromwell/run.py
+++ b/alto/commands/cromwell/run.py
@@ -1,0 +1,57 @@
+import argparse, requests
+from alto.utils import parse_dockstore_workflow, get_dockstore_workflow
+
+
+def submit_to_cromwell(server, port, method_str, wf_input_path, no_cache, no_ssl_verify):
+    organization, collection, workflow, version = parse_dockstore_workflow(method_str)
+    workflow_def = get_dockstore_workflow(organization, collection, workflow, version, ssl_verify=not no_ssl_verify)
+
+    files = {
+        'workflowInputs': open(wf_input_path, 'rb'),
+    }
+
+    data = {
+        'workflowUrl': workflow_def['url'],
+    }
+
+    resp = requests.post(
+        f"http://{server}:{port}/api/workflows/v1",
+        files=files,
+        data=data,
+    )
+
+    resp_dict = resp.json()
+
+    if resp.status_code == 201:
+        print(f"Job {resp_dict['id']} is in status {resp_dict['status']}.")
+    else:
+        print(resp_dict['message'])
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Submit WDL jobs to a Cromwell server for execution. \
+        Workflows should be from Dockstore. For Dockstore workflows, collection and name would be used as config namespace and name respectively. \
+        If local files are detected, automatically upload files to the workspace Google Cloud bucket. \
+        After a successful submission, a URL pointing to the job status would be printed out."
+    )
+    parser.add_argument('-s', '--server', dest='server', action='store', required=True,
+        help="Server hostname or IP address."
+    )
+    parser.add_argument('-p', '--port', dest='port', action='store', default='8000',
+        help="Port number for Cromwell service. The default port is 8000."
+    )
+    parser.add_argument('-m', '--method', dest='method_str', action='store', required=True,
+        help="Workflow name from Dockstore, with name specified as organization:collection:name:version (e.g. broadinstitute:cumulus:cumulus:1.5.0). \
+        The default version would be used if version is omitted."
+    )
+    parser.add_argument('-i', '--input', dest='input', action='store', required=True,
+        help="Path to a local JSON file specifying workflow inputs."
+    )
+    parser.add_argument('--no-cache', dest='no_cache', action='store_true', help="Disable call caching.")
+    parser.add_argument('--no-ssl-verify', dest='no_ssl_verify', action='store_true', default=False,
+        help="Disable SSL verification for web requests. Not recommended for general usage, but can be useful for intra-networks which don't support SSL verification."
+    )
+
+    args = parser.parse_args(argv)
+
+    submit_to_cromwell(args.server, args.port, args.method_str, args.input, args.no_cache, args.no_ssl_verify)

--- a/alto/utils/firecloud_utils.py
+++ b/alto/utils/firecloud_utils.py
@@ -25,7 +25,7 @@ def parse_firecloud_workflow(workflow_string: str) -> Tuple[str, str, int]:
     Examples
     --------
     >>> method_namespace, method_name, method_version = parse_firecloud_workflow('cumulus/cumulus/43')
-    """ 
+    """
     fields = workflow_string.split('/')
     if len(fields) < 2 or len(fields) > 3:
         raise ValueError(f"workflow_string should contain only 2 or 3 items. But {workflow_string} contains {len(fields)} items!")
@@ -66,7 +66,7 @@ def get_firecloud_workflow(method_namespace: str, method_name: str, method_versi
     method_record = None
 
     if method_version is not None:
-        method_def = fapi.get_repository_method(method_namespace, method_name, method_version)    
+        method_def = fapi.get_repository_method(method_namespace, method_name, method_version)
         if method_def.status_code != 200:
             raise ValueError(f"Unable to fetch workflow {method_namespace}/{method_name}/{method_version} - {method_def.json()}!")
         method_record = method_def.json()
@@ -127,7 +127,7 @@ def update_workflow_config_in_workspace(config_namespace: str, config_name: str,
 
 
 def submit_a_job_to_terra(workspace_namespace: str, workspace_name: str, config_namespace: str, config_name: str, use_callcache: bool = True) -> str:
-    """Create a job submission to Terra and if success, return a URL for checking job status. 
+    """Create a job submission to Terra and if success, return a URL for checking job status.
     """
     launch_submission = fapi.create_submission(workspace_namespace, workspace_name, config_namespace, config_name, use_callcache = use_callcache)
     if launch_submission.status_code != 201:


### PR DESCRIPTION
* Add `run` and `check_status` commands in `alto cromwell`.
* Change `url` field in the object returned by `get_dockstore_workflow` function to GitHub download URL.
* Add `ssl_verify` argument to `get_dockstore_workflow` to allow disabling SSL verification. This has to be turned off in some intra-network settings.
* Make altocumulus ignore urllib3's insecure request warnings in command line usage.