### PR TITLE
Upload local input data if needed

### DIFF
--- a/alto/commands/cromwell/run.py
+++ b/alto/commands/cromwell/run.py
@@ -1,13 +1,36 @@
 import argparse, requests
+from alto.utils.io_utils import read_wdl_inputs, upload_to_cloud_bucket
 from alto.utils import parse_dockstore_workflow, get_dockstore_workflow
 
 
-def submit_to_cromwell(server, port, method_str, wf_input_path, no_cache, no_ssl_verify):
+def parse_bucket_folder_url(bucket):
+    assert '://' in bucket, "Bucket folder URL must start with 's3://' or 'gs://'."
+
+    res = bucket.split('://')
+    backend = 'aws'
+    if res[0] == 'gs':
+        backend = 'gcp'
+
+    res2 = res[1].split('/')
+    bucket_id = res2[0]
+    bucket_folder = '/'.join(res2[1:])
+
+    return (backend, bucket_id, bucket_folder)
+
+
+def submit_to_cromwell(server, port, method_str, wf_input_path, out_json, bucket, no_cache, no_ssl_verify):
     organization, collection, workflow, version = parse_dockstore_workflow(method_str)
     workflow_def = get_dockstore_workflow(organization, collection, workflow, version, ssl_verify=not no_ssl_verify)
 
+    inputs = read_wdl_inputs(wf_input_path)
+
+    # Upload input data to cloud bucket if needed.
+    if out_json is not None:
+        backend, bucket_id, bucket_folder = parse_bucket_folder_url(bucket)
+        upload_to_cloud_bucket(inputs, backend, bucket_id, bucket_folder, out_json, False)
+
     files = {
-        'workflowInputs': open(wf_input_path, 'rb'),
+        'workflowInputs': open(out_json, 'rb'),
     }
 
     data = {
@@ -47,6 +70,12 @@ def main(argv):
     parser.add_argument('-i', '--input', dest='input', action='store', required=True,
         help="Path to a local JSON file specifying workflow inputs."
     )
+    parser.add_argument('-o', '--upload', dest='out_json', metavar='<updated_json>', action='store',
+        help="Upload files/directories to the workspace cloud bucket and output updated input json (with local path replaced by cloud bucket urls) to <updated_json>.")
+    parser.add_argument('-b', '--bucket', dest='bucket', action='store', metavar='[s3|gs]://<bucket-name>/<bucket-folder>',
+        help="Cloud bucket folder for uploading local input data. Start with 's3://' if an AWS S3 bucket is used, 'gs://' for a Google bucket. \
+        Must be specified when '-o' option is used."
+    )
     parser.add_argument('--no-cache', dest='no_cache', action='store_true', help="Disable call caching.")
     parser.add_argument('--no-ssl-verify', dest='no_ssl_verify', action='store_true', default=False,
         help="Disable SSL verification for web requests. Not recommended for general usage, but can be useful for intra-networks which don't support SSL verification."
@@ -54,4 +83,4 @@ def main(argv):
 
     args = parser.parse_args(argv)
 
-    submit_to_cromwell(args.server, args.port, args.method_str, args.input, args.no_cache, args.no_ssl_verify)
+    submit_to_cromwell(args.server, args.port, args.method_str, args.input, args.out_json, args.bucket, args.no_cache, args.no_ssl_verify)

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -183,4 +183,4 @@ def upload_to_cloud_bucket(inputs: Dict[str, str], backend: str, bucket: str, bu
 
     if out_json is not None:
         with open(out_json, 'w') as fout:
-            json.dump(inputs, fout)
+            json.dump(inputs, fout, indent=4)


### PR DESCRIPTION
* `alto cromwell run` can now upload local input data if requested: `-o` and `-b` options.
* After uploading, make the auto-generated workflow input JSON file in human readable format.