### PR TITLE
Fix a bug when uploading to cloud bucket

### DIFF
--- a/alto/commands/cromwell/run.py
+++ b/alto/commands/cromwell/run.py
@@ -11,7 +11,7 @@ def parse_bucket_folder_url(bucket):
     if res[0] == 'gs':
         backend = 'gcp'
 
-    res2 = res[1].split('/')
+    res2 = res[1].strip('/').split('/')  # Remove the trailing slash if exists.
     bucket_id = res2[0]
     bucket_folder = '/'.join(res2[1:])
 


### PR DESCRIPTION
### Issue

If specifying `alto cromwell run ... -b gs://bucket-id/bucket-folder/`, the resulting uploaded files, especially sample sheets will have GS URI like `gs://bucket-id/bucket-folder//sample_sheet.csv`, which is invalid.

### Solution

Remove the trailing slash when parsing GS bucket URI.