### PR TITLE
Fix issue when uploading bucket folder is specified

### DIFF
--- a/alto/commands/cromwell/run.py
+++ b/alto/commands/cromwell/run.py
@@ -11,7 +11,7 @@ def parse_bucket_folder_url(bucket):
     if res[0] == 'gs':
         backend = 'gcp'
 
-    res2 = res[1].strip('/').split('/')  # Remove the trailing slash if exists.
+    res2 = res[1].split('/')  # Remove the trailing slash if exists.
     bucket_id = res2[0]
     bucket_folder = '/'.join(res2[1:])
 

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -154,7 +154,7 @@ def upload_to_cloud_bucket(inputs: Dict[str, str], backend: str, bucket: str, bu
     >>> upload_to_cloud_bucket(inputs, 'gcp', 'my_bucket', 'input_files', 'updated_inputs.json', False)
     """
     if bucket_folder is not None:
-        bucket += f'/{bucket_folder}'
+        bucket += f"/{bucket_folder.strip('/')}"
 
     url_gen = cloud_url_factory(backend, bucket)
     input_file_to_output_url = {}


### PR DESCRIPTION
A more thorough fix for Issue #5 : now both Terra and Cromwell commands should work well with bucket folder URI ending with trailing slashes.