### PR TITLE
Add get_logs and get_metadata subcommands of cromwell command

### DIFF
--- a/alto/commands/cromwell/__init__.py
+++ b/alto/commands/cromwell/__init__.py
@@ -1,11 +1,11 @@
 import sys, argparse
-from . import run, check_status, abort
+from . import run, check_status, abort, get_metadata, get_logs
 
 def main(args):
-    str2module = {'run': run, 'check_status': check_status, 'abort': abort}
+    str2module = {'run': run, 'check_status': check_status, 'abort': abort, 'get_metadata': get_metadata, 'get_logs': get_logs}
 
     parser = argparse.ArgumentParser(description='Run a terra sub-command.')
-    parser.add_argument('subcommand', help='The sub-command', choices=['run', 'check_status', 'abort'])
+    parser.add_argument('subcommand', help='The sub-command', choices=['run', 'check_status', 'abort', 'get_metadata', 'get_logs'])
     parser.add_argument('subcommand_args', help='The sub-command arguments', nargs=argparse.REMAINDER)
     my_args = parser.parse_args(args)
 

--- a/alto/commands/cromwell/get_logs.py
+++ b/alto/commands/cromwell/get_logs.py
@@ -1,0 +1,75 @@
+import argparse, json, requests
+
+from alto.utils import run_command
+
+
+def get_localize_path(cloud_uri, job_id):
+    uri_list = cloud_uri.split('://')
+    backend = 'local'
+    if len(uri_list) > 1:
+        backend = 'aws' if uri_list[0] == 's3' else 'gcp'
+
+    local_path = cloud_uri[cloud_uri.find(job_id):]
+
+    return backend, local_path
+
+
+def get_remote_log_file(cloud_uri, job_id):
+    backend, local_path = get_localize_path(cloud_uri, job_id)
+    try:
+        run_command(['strato', 'cp', '--backend', backend, cloud_uri, local_path], dry_run=False)
+    except:
+        return
+
+def get_logs_per_task(server, port, job_id, meta_dict):
+    # For tasks with no subworkflow ID
+    resp_top = requests.get(f"http://{server}:{port}/api/workflows/v1/{job_id}/logs")
+    resp_top_dict = resp_top.json()
+
+    processed_tasks = set()
+    for task_name, log_list in resp_top_dict['calls'].items():
+        for log in log_list:
+            get_remote_log_file(log['stderr'], job_id)
+            get_remote_log_file(log['stdout'], job_id)
+        processed_tasks.add(task_name)
+
+    # For tasks with subworkflow ID
+    for task_name, task_list in meta_dict['calls'].items():
+        if task_name not in processed_tasks:
+            for task in task_list:
+                subworkflow_id = task['subWorkflowId']
+                resp_task = requests.get(f"http://{server}:{port}/api/workflows/v1/{subworkflow_id}/logs")
+                resp_task_dict = resp_task.json()
+                for task_name, log_list in resp_task_dict['calls'].items():
+                    for log in log_list:
+                        get_remote_log_file(log['stderr'], job_id)
+                        get_remote_log_file(log['stdout'], job_id)
+
+
+
+def get_logs(server, port, job_id):
+    resp_meta = requests.get(f"http://{server}:{port}/api/workflows/v1/{job_id}/metadata")
+    meta_dict = resp_meta.json()
+
+    if resp_meta.status_code == 200:
+        get_logs_per_task(server, port, job_id, meta_dict)
+    else:
+        print(meta_dict['message'])
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Get the logs for a submitted job."
+    )
+    parser.add_argument('-s', '--server', dest='server', action='store', required=True,
+        help="Server hostname or IP address."
+    )
+    parser.add_argument('-p', '--port', dest='port', action='store', default='8000',
+        help="Port number for Cromwell service. The default port is 8000."
+    )
+    parser.add_argument('--id', dest='job_id', action='store', required=True,
+        help="Workflow ID returned in 'alto cromwell run' command."
+    )
+
+    args = parser.parse_args(argv)
+
+    get_logs(args.server, args.port, args.job_id)

--- a/alto/commands/cromwell/get_metadata.py
+++ b/alto/commands/cromwell/get_metadata.py
@@ -1,18 +1,19 @@
-import argparse, requests
+import argparse, json, requests
 
 
-def get_status(server, port, job_id):
-    resp = requests.get(f"http://{server}:{port}/api/workflows/v1/{job_id}/status")
+def get_metadata(server, port, job_id):
+    resp = requests.get(f"http://{server}:{port}/api/workflows/v1/{job_id}/metadata")
     resp_dict = resp.json()
 
     if resp.status_code == 200:
-        print(f"Job {resp_dict['id']} is in status {resp_dict['status']}.")
+        with open(f"{job_id}.metadata.json", 'w') as fp:
+            json.dump(resp_dict, fp, indent=4)
     else:
         print(resp_dict['message'])
 
 def main(argv):
     parser = argparse.ArgumentParser(
-        description="Check the current status for a workflow on a Cromwell server."
+        description="Get workflow and call-level metadata for a submitted job."
     )
     parser.add_argument('-s', '--server', dest='server', action='store', required=True,
         help="Server hostname or IP address."
@@ -26,4 +27,4 @@ def main(argv):
 
     args = parser.parse_args(argv)
 
-    get_status(args.server, args.port, args.job_id)
+    get_metadata(args.server, args.port, args.job_id)

--- a/alto/commands/cromwell/run.py
+++ b/alto/commands/cromwell/run.py
@@ -1,4 +1,4 @@
-import argparse, requests
+import argparse, requests, sys
 from alto.utils.io_utils import read_wdl_inputs, upload_to_cloud_bucket
 from alto.utils import parse_dockstore_workflow, get_dockstore_workflow
 
@@ -18,7 +18,7 @@ def parse_bucket_folder_url(bucket):
     return (backend, bucket_id, bucket_folder)
 
 
-def submit_to_cromwell(server, port, method_str, wf_input_path, out_json, bucket, no_cache, no_ssl_verify):
+def submit_to_cromwell(server, port, method_str, wf_input_path, out_json, bucket, no_ssl_verify):
     organization, collection, workflow, version = parse_dockstore_workflow(method_str)
     workflow_def = get_dockstore_workflow(organization, collection, workflow, version, ssl_verify=not no_ssl_verify)
 
@@ -47,6 +47,7 @@ def submit_to_cromwell(server, port, method_str, wf_input_path, out_json, bucket
 
     if resp.status_code == 201:
         print(f"Job {resp_dict['id']} is in status {resp_dict['status']}.")
+        print(f"{resp_dict['id']}\n", file=sys.stderr)
     else:
         print(resp_dict['message'])
 
@@ -76,11 +77,11 @@ def main(argv):
         help="Cloud bucket folder for uploading local input data. Start with 's3://' if an AWS S3 bucket is used, 'gs://' for a Google bucket. \
         Must be specified when '-o' option is used."
     )
-    parser.add_argument('--no-cache', dest='no_cache', action='store_true', help="Disable call caching.")
+    #parser.add_argument('--no-cache', dest='no_cache', action='store_true', help="Disable call caching.")
     parser.add_argument('--no-ssl-verify', dest='no_ssl_verify', action='store_true', default=False,
         help="Disable SSL verification for web requests. Not recommended for general usage, but can be useful for intra-networks which don't support SSL verification."
     )
 
     args = parser.parse_args(argv)
 
-    submit_to_cromwell(args.server, args.port, args.method_str, args.input, args.out_json, args.bucket, args.no_cache, args.no_ssl_verify)
+    submit_to_cromwell(args.server, args.port, args.method_str, args.input, args.out_json, args.bucket, args.no_ssl_verify)


### PR DESCRIPTION
In `alto cromwell` command:

* Add `get_metadata` command to get workflow and call-level metadata as JSON file for a specified job.
* Add `get_logs` command to get logs of calls and subworkflows of a specified job.
* Update:
  * `check_status` command: No need to keep `--no-ssl-verify` option.
  * `run` command: 
    * Temporarily remove `--no-cache` because it's not implemented yet.
    * Write the submitted job's ID to `sys.stderr`.