### PR TITLE
Congee

### DIFF
--- a/alto/commands/cromwell/run.py
+++ b/alto/commands/cromwell/run.py
@@ -32,7 +32,7 @@ def wait_and_check(server, port, job_id, time_out, freq=60):
         resp = requests.get(url)
         resp_dict = resp.json()
         if resp.status_code == 200:
-            if resp_dict['status'] in ['Succeeded', 'Failed', 'Aborted', 'Aborting']:
+            if resp_dict['status'] in ['Succeeded', 'Failed', 'Aborted']:
                 break
         else:
             print(resp_dict['message'])


### PR DESCRIPTION
In `cromwell run` command:
* `--no-cache` only disable reading from cache.
* `-m` now accepts 3 kinds of workflow:
  * Workflow from Dockstore;
  * An HTTP or HTTPS URL of a WDL file;
  * A local path to a WDL file.
* `--time-out`: do not terminate for `Aborting` status.