### PR TITLE
Only print job's ID and final status for `--time-out` option in `cromwell run` command

### DIFF
--- a/alto/commands/cromwell/run.py
+++ b/alto/commands/cromwell/run.py
@@ -80,7 +80,7 @@ def submit_to_cromwell(server, port, method_str, wf_input_path, out_json, bucket
     # Upload input data to cloud bucket if needed.
     if out_json is not None:
         backend, bucket_id, bucket_folder = parse_bucket_folder_url(bucket)
-        upload_to_cloud_bucket(inputs, backend, bucket_id, bucket_folder, out_json, False)
+        upload_to_cloud_bucket(inputs, backend, bucket_id, bucket_folder, out_json, dry_run=False, verbose=True if time_out is None else False)
 
     files['workflowInputs'] = open(wf_input_path if out_json is None else out_json, 'rb')
 

--- a/alto/utils/__init__.py
+++ b/alto/utils/__init__.py
@@ -1,12 +1,18 @@
-import subprocess
+import sys, subprocess
 from typing import List
 
 def run_command(command: List[str], dry_run: bool) -> None:
     """ Print command and execute it (if dry_run == False).
     """
-    print(' '.join(command))
-    if not dry_run:
-        subprocess.check_call(command)
+    old_stdout = sys.stdout
+    sys.stdout = sys.stderr
+
+    try:
+        print(' '.join(command))
+        if not dry_run:
+            subprocess.check_call(command)
+    finally:
+        sys.stdout = old_stdout
 
 from .io_utils import read_wdl_inputs, upload_to_cloud_bucket
 from .dockstore_utils import parse_dockstore_workflow, get_dockstore_workflow

--- a/alto/utils/__init__.py
+++ b/alto/utils/__init__.py
@@ -1,18 +1,22 @@
 import sys, subprocess
 from typing import List
 
-def run_command(command: List[str], dry_run: bool) -> None:
+def run_command(
+    command: List[str],
+    dry_run: bool,
+    suppress_stdout: bool = False,
+    suppress_stderr: bool = False,
+) -> None:
     """ Print command and execute it (if dry_run == False).
     """
-    old_stdout = sys.stdout
-    sys.stdout = sys.stderr
+    cur_stdout = subprocess.DEVNULL if suppress_stdout else None
+    cur_stderr = subprocess.DEVNULL if suppress_stderr else None
 
-    try:
+    if not suppress_stdout:
         print(' '.join(command))
-        if not dry_run:
-            subprocess.check_call(command)
-    finally:
-        sys.stdout = old_stdout
+
+    if not dry_run:
+        subprocess.check_call(command, stdout=cur_stdout, stderr=cur_stderr)
 
 from .io_utils import read_wdl_inputs, upload_to_cloud_bucket
 from .dockstore_utils import parse_dockstore_workflow, get_dockstore_workflow

--- a/alto/utils/__init__.py
+++ b/alto/utils/__init__.py
@@ -1,4 +1,4 @@
-import sys, subprocess
+import subprocess
 from typing import List
 
 def run_command(

--- a/alto/utils/bcl_utils.py
+++ b/alto/utils/bcl_utils.py
@@ -35,7 +35,7 @@ def path_is_flowcell(path: str) -> bool:
     return os.path.isdir(path) and os.path.exists(f'{path}/RunInfo.xml')
 
 
-def transfer_flowcell(source: str, dest: str, backend: str, lanes: List[str], dry_run: bool) -> None:
+def transfer_flowcell(source: str, dest: str, backend: str, lanes: List[str], dry_run: bool, verbose: bool = True) -> None:
     """Transfer one flowcell (with selected lanes) to cloud
 
     Parameters
@@ -59,15 +59,15 @@ def transfer_flowcell(source: str, dest: str, backend: str, lanes: List[str], dr
     --------
     >>> transfer_flowcell('flowcell', 'gs://my_bucket/flowcell', 'gcp', ['*'], False)
     """
-    run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/RunInfo.xml', f'{dest}/RunInfo.xml'], dry_run)
+    run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/RunInfo.xml', f'{dest}/RunInfo.xml'], dry_run, suppress_stdout=not verbose)
     if not os.path.exists(f'{source}/RTAComplete.txt'):
         raise FileNotFoundError("Cannot find RTAComplete.txt. Please check if sequencing is completed!")
-    run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/RTAComplete.txt', f'{dest}/RTAComplete.txt'], dry_run)
+    run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/RTAComplete.txt', f'{dest}/RTAComplete.txt'], dry_run, suppress_stdout=not verbose)
 
     if os.path.exists(f'{source}/runParameters.xml'):
-        run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/runParameters.xml', f'{dest}/runParameters.xml'], dry_run)
+        run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/runParameters.xml', f'{dest}/runParameters.xml'], dry_run, suppress_stdout=not verbose)
     elif os.path.exists(f'{source}/RunParameters.xml'):
-        run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/RunParameters.xml', f'{dest}/RunParameters.xml'], dry_run)
+        run_command(['strato', 'cp', '--backend', backend, '--ionice', f'{source}/RunParameters.xml', f'{dest}/RunParameters.xml'], dry_run, suppress_stdout=not verbose)
     else:
         raise FileNotFoundError("Cannot find either runParameters.xml or RunParameters.xml!")
 
@@ -82,12 +82,12 @@ def transfer_flowcell(source: str, dest: str, backend: str, lanes: List[str], dr
     # copy bcl files
     for lane in lanes:
         lane_string = basecall_string + '/{1}'
-        run_command(['strato', 'sync', '--backend', backend, '--ionice', '-m', lane_string.format(source, lane), lane_string.format(dest, lane)], dry_run)
+        run_command(['strato', 'sync', '--backend', backend, '--ionice', '-m', lane_string.format(source, lane), lane_string.format(dest, lane)], dry_run, suppress_stdout=not verbose)
     # copy locs files
     locs_string = '{0}/Data/Intensities/s.locs'
     if os.path.exists(locs_string.format(source)):
-        run_command(['strato', 'cp', '--backend', backend, '--ionice', locs_string.format(source), locs_string.format(dest)], dry_run)
+        run_command(['strato', 'cp', '--backend', backend, '--ionice', locs_string.format(source), locs_string.format(dest)], dry_run, suppress_stdout=not verbose)
     else:
         locs_string = '{0}/Data/Intensities/{1}'
         for lane in lanes:
-            run_command(['strato', 'sync', '--backend', backend, '--ionice', '-m', locs_string.format(source, lane), locs_string.format(dest, lane)], dry_run)
+            run_command(['strato', 'sync', '--backend', backend, '--ionice', '-m', locs_string.format(source, lane), locs_string.format(dest, lane)], dry_run, suppress_stdout=not verbose)


### PR DESCRIPTION
In `cromwell run` command:
* If `--time-out` option is set, only print job's ID and final status when it terminates.