### PR TITLE
Upload fastq folders

### DIFF
--- a/alto/commands/upload.py
+++ b/alto/commands/upload.py
@@ -46,4 +46,12 @@ def main(argv):
             import uuid
             inputs.update({str(uuid.uuid1()): path})
 
-    upload_to_cloud_bucket(inputs, backend, bucket, args.bucket_folder, args.out_json, args.dry_run, args.profile)
+    upload_to_cloud_bucket(
+        inputs=inputs,
+        backend=backend,
+        bucket=bucket,
+        bucket_folder=args.bucket_folder,
+        out_json=args.out_json,
+        dry_run=args.dry_run,
+        profile=args.profile,
+    )

--- a/alto/utils/fastq_utils.py
+++ b/alto/utils/fastq_utils.py
@@ -9,10 +9,33 @@ def folder_is_fastq(
     if (prefix is None) or (not os.path.isdir(path)):
         return None
 
-    if len(glob.glob(f"{path}/{prefix}_*.fastq.gz")) > 0:
+    # Check folder permission.
+    if not os.access(path, os.X_OK):
+        raise PermissionError(f"Need execution access to folder '{path}'!")
+
+    fa_list = glob.glob(f"{path}/{prefix}_*.fastq.gz")
+    if len(fa_list) > 0:
+        # Check fastq file permission.
+        for f in fa_list:
+            if not os.access(f, os.R_OK):
+                raise PermissionError(f"Need read access to '{f}'!")
+
         return os.path.abspath(f"{path}/{prefix}_*.fastq.gz")
-    elif os.path.isdir(f"{path}/{prefix}") and (len(glob.glob(f"{path}/{prefix}/{prefix}_*.fastq.gz")) > 0):
-        return os.path.abspath(f"{path}/{prefix}/{prefix}_*.fastq.gz")
+    elif os.path.isdir(f"{path}/{prefix}"):
+        # Check subfolder permission.
+        if not os.access(f"{path}/{prefix}", os.X_OK):
+            raise PermissionError(f"Need execution access to folder '{path}/{prefix}'!")
+
+        fa_list = glob.glob(f"{path}/{prefix}/{prefix}_*.fastq.gz")
+        if len(fa_list) > 0:
+            # Check fastq file permission.
+            for f in fa_list:
+                if not os.access(f, os.R_OK):
+                    raise PermissionError(f"Need read access to '{f}'!")
+
+            return os.path.abspath(f"{path}/{prefix}/{prefix}_*.fastq.gz")
+        else:
+            return None
     else:
         return None
 

--- a/alto/utils/fastq_utils.py
+++ b/alto/utils/fastq_utils.py
@@ -1,0 +1,37 @@
+import glob, os
+from alto.utils import run_command
+from typing import Optional
+
+def folder_is_fastq(
+    path: str,
+    prefix: Optional[str] = None,
+) -> Optional[str]:
+    if (prefix is None) or (not os.path.isdir(path)):
+        return None
+
+    if len(glob.glob(f"{path}/{prefix}_*.fastq.gz")) > 0:
+        return os.path.abspath(f"{path}/{prefix}_*.fastq.gz")
+    elif os.path.isdir(f"{path}/{prefix}") and (len(glob.glob(f"{path}/{prefix}/{prefix}_*.fastq.gz")) > 0):
+        return os.path.abspath(f"{path}/{prefix}/{prefix}_*.fastq.gz")
+    else:
+        return None
+
+
+
+def transfer_fastq(
+    source: str,
+    dest: str,
+    backend: str,
+    dry_run: bool,
+    profile: Optional[str] = None,
+    verbose: bool = True,
+) -> None:
+    if os.path.isdir(source):
+        strato_cmd = ['strato', 'sync', '--backend', backend, '--ionice', '-m', '--quiet', source, dest]
+    else:
+        strato_cmd = ['strato', 'cp', '--backend', backend, '--ionice', '-m', '--quiet', source, os.path.dirname(dest) + '/']
+
+    if profile is not None:
+        strato_cmd.extend(['--profile', profile])
+
+    run_command(strato_cmd, dry_run, suppress_stdout=not verbose)

--- a/alto/utils/fastq_utils.py
+++ b/alto/utils/fastq_utils.py
@@ -17,7 +17,6 @@ def folder_is_fastq(
         return None
 
 
-
 def transfer_fastq(
     source: str,
     dest: str,

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -221,6 +221,10 @@ def upload_to_cloud_bucket(
         Path for the JSON file storing updated inputs.
     dry_run: `bool`
         If dry run, only print commands but do not execute.
+    verbose: `bool`, default: ``True``
+        If print out the underlying upload commands on screen.
+    profile: `str`, default: ``None``
+        For AWS backend only, it's used for specifying a non-default AWS profile.
 
     Returns
     -------
@@ -228,7 +232,7 @@ def upload_to_cloud_bucket(
 
     Examples
     --------
-    >>> upload_to_cloud_bucket(inputs, 'gcp', 'my_bucket', 'input_files', 'updated_inputs.json', False)
+    >>> upload_to_cloud_bucket(inputs, 'gcp', 'my_bucket', 'input_files', 'updated_inputs.json')
     """
     if bucket_folder is not None:
         bucket += f"/{bucket_folder.strip('/')}"

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -132,6 +132,11 @@ def transfer_sample_sheet(
     """
     is_changed = False
 
+    # Terminate if no access to sample sheet.
+    if not os.access(input_file, os.R_OK):
+        raise PermissionError(f"Need read access to '{input_file}'!")
+
+    # If cannot process, upload its original content.
     try:
         df = pd.read_csv(input_file, sep=None, engine='python', header=None, index_col=False)
     except Exception:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pandas
 python-dateutil
 matplotlib
 six
-stratocumulus
+stratocumulus>=0.1.6
 importlib_metadata>=0.7; python_version < '3.8'


### PR DESCRIPTION
## Add support on uploading fastq folders

Require Stratocumulus at least `v0.1.6` to work with AWS backend.

Steps:
* Track column of samples: if `Library` presents, use it; otherwise, look for `Sample`.
* If encountering a local folder, justify if it's a fastq folder by `folder_is_fastq` function. 
  * This function returns `None` if it's not a fastq folder.
  * Otherwise, it returns the file pattern: either `<folder-name>/<sample-name>`, or `<folder-name>/<sample-name>_*.fastq.gz`, depending on the actual folder structure.
* Determine the `source` and `dest` based on if the folder is a fastq folder or a BCL folder.
* If a fastq folder:
  * Set `<folder-name>/<sample-name>` as the key in `input_file_to_output_url` dictionary, with `<bucket-folder>/<sample-name>` being the value.
  * Use `transfer_fastq` function to upload fastq files/subfolders to `<bucket-folder>`.

`transfer_fastq` function is used within `transfer_data` function, which is called by `transfer_sample_sheet`.

## Early termination if no access

Raise `PermissionError` if:
* Input sample sheet is not readable.
* Fastq folders are not executable.
* Fastq files are not readable.