### PR TITLE
Bug fix on sample sheet uploading

### DIFF
--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -147,6 +147,7 @@ def transfer_sample_sheet(
     flowcells = {}
     col_names = np.char.array(df.iloc[0,:], unicode = True).lower()
 
+    # Upload BCL folder or FASTQ files if needed.
     if ('flowcell' in col_names) or ('location' in col_names):
         flowcell_keyword = 'flowcell' if 'flowcell' in col_names else 'location'
         df.columns = col_names
@@ -160,11 +161,24 @@ def transfer_sample_sheet(
             raise ValueError("Cannot detect either Library or Sample column in the sample sheet!")
 
         for _, row in df[1:].iterrows():
-            path = os.path.abspath(row[flowcell_keyword])
-            if not os.path.isdir(path):
-                raise ValueError(f"{path} is not a folder!")
-            if not os.access(path, os.X_OK):
-                raise PermissionError(f"Need execution access to folder '{path}'!")
+            if isinstance(row[flowcell_keyword], str):
+                path = row[flowcell_keyword].strip()
+
+                if not os.path.exists(path):
+                    if path.startswith("gs://") or path.startswith("s3://"):
+                        continue
+                else:
+                    raise ValueError(f"{path} does not exist!")
+
+                if not os.path.isdir(path):
+                    raise ValueError(f"{path} is not a folder!")
+
+                if not os.access(path, os.X_OK):
+                    raise PermissionError(f"Need execution access to folder '{path}'!")
+            else:
+                raise ValueError(f"{row[flowcell_keyword]} is not in string type!")
+
+            path = os.path.abspath(path)
 
             flowcell = None
             if path in flowcells:

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -164,21 +164,18 @@ def transfer_sample_sheet(
             if isinstance(row[flowcell_keyword], str):
                 path = row[flowcell_keyword].strip()
 
-                if not os.path.exists(path):
-                    if path.startswith("gs://") or path.startswith("s3://"):
-                        continue
-                else:
-                    raise ValueError(f"{path} does not exist!")
+                if path.startswith("gs://") or path.startswith("s3://"):
+                    continue
 
+                path = os.path.abspath(path)
+                if not os.path.exists(path):
+                    raise ValueError(f"{path} does not exist!")
                 if not os.path.isdir(path):
                     raise ValueError(f"{path} is not a folder!")
-
                 if not os.access(path, os.X_OK):
                     raise PermissionError(f"Need execution access to folder '{path}'!")
             else:
                 raise ValueError(f"{row[flowcell_keyword]} is not in string type!")
-
-            path = os.path.abspath(path)
 
             flowcell = None
             if path in flowcells:


### PR DESCRIPTION
## Issue

Altocumulus tries to upload BCL folders or FASTQ files before checking if the provided path is a Cloud URI or a local path. It brings problems, because Python's `os.path.abspath("gs://bucket-name/folder-name")` returns the following string:
```
/path/to/local/cwd/gs://bucket-name/folder-name
``` 
and thus the sample sheet uploading fails.

## Solution

I reorganize the checking on `path` at the BCL/FASTQ step to include the checking on if it is a Cloud URI (only consider S3 and GS URIs for now). And if encountering a Cloud URI, simply skip the rest of process and go to the next path.