### PR TITLE
Give informative error message for jobs failed before execution

### DIFF
--- a/alto/commands/cromwell/list_jobs.py
+++ b/alto/commands/cromwell/list_jobs.py
@@ -94,6 +94,7 @@ def list_jobs(
     if resp.status_code == 200:
         df_jobs = pd.DataFrame.from_records(resp_dict["results"])
         if 'name' in df_jobs:
+            df_jobs.loc[(df_jobs['name'].isna()) & (df_jobs['status'].isin(['Submitted', 'Running'])), 'name'] = '<under checking>'
             df_jobs['name'] = df_jobs['name'].fillna('<failed before exec>')
         show_jobs(df_jobs, num_shown=num_shown)
     else:

--- a/alto/commands/cromwell/list_jobs.py
+++ b/alto/commands/cromwell/list_jobs.py
@@ -94,7 +94,7 @@ def list_jobs(
     if resp.status_code == 200:
         df_jobs = pd.DataFrame.from_records(resp_dict["results"])
         if 'name' in df_jobs:
-            df_jobs['name'] = df_jobs['name'].fillna('')
+            df_jobs['name'] = df_jobs['name'].fillna('<job fails before execution>')
         show_jobs(df_jobs, num_shown=num_shown)
     else:
         print(resp_dict["message"])

--- a/alto/commands/cromwell/list_jobs.py
+++ b/alto/commands/cromwell/list_jobs.py
@@ -94,7 +94,7 @@ def list_jobs(
     if resp.status_code == 200:
         df_jobs = pd.DataFrame.from_records(resp_dict["results"])
         if 'name' in df_jobs:
-            df_jobs['name'] = df_jobs['name'].fillna('<job fails before execution>')
+            df_jobs['name'] = df_jobs['name'].fillna('<failed before exec>')
         show_jobs(df_jobs, num_shown=num_shown)
     else:
         print(resp_dict["message"])


### PR DESCRIPTION
For any job with workflow name not determined:
* If the job is in `Submitted` or `Running` status, assign `<under checking>` as name, because Cromwell is currently running a runtime type checker on its inputs.
* Otherwise, assign `<failed before exec>` as name, because the job has failed at runtime type checking, and thus terminates before execution.