### PR TITLE
Don't use nested indexing when doing assignment

### DIFF
--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -215,7 +215,6 @@ def transfer_sample_sheet(
                 if not os.path.exists(path):
                     raise ValueError(f"{path} does not exist!")
                 if not os.path.isdir(path):
-                    #raise ValueError(f"{path} is not a folder!")
                     break  # For file type Location values
                 elif not os.access(path, os.X_OK):
                     raise PermissionError(f"Need execution access to folder '{path}'!")

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -215,8 +215,9 @@ def transfer_sample_sheet(
                 if not os.path.exists(path):
                     raise ValueError(f"{path} does not exist!")
                 if not os.path.isdir(path):
-                    raise ValueError(f"{path} is not a folder!")
-                if not os.access(path, os.X_OK):
+                    #raise ValueError(f"{path} is not a folder!")
+                    break  # For file type Location values
+                elif not os.access(path, os.X_OK):
                     raise PermissionError(f"Need execution access to folder '{path}'!")
             else:
                 raise ValueError(f"{row[flowcell_keyword]} is not in string type!")

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -238,7 +238,7 @@ def transfer_sample_sheet(
             else:
                 flowcell.manager.update_samples(row[sample_keyword])
 
-    for _, row in df[1:].iterrows():
+    for idxr, row in df[1:].iterrows():
         for idxc, value in row.iteritems():
             if isinstance(value, str) and os.path.exists(value):
                 source = os.path.abspath(value)
@@ -257,7 +257,7 @@ def transfer_sample_sheet(
                     )
                     input_file_to_output_url[source] = sub_url
 
-                row[idxc] = sub_url
+                df.loc[idxr, idxc] = sub_url
                 is_changed = True
 
     if is_changed:


### PR DESCRIPTION
Use `.loc[row_index, col_index]` instead of `row[col_index]` for assignment. Reasons:
* Avoid `SettingWithCopy` warning.
* If the data frame is modified, the old assignment won't work.

Don't throw exception for file-type values of `Flowcell` or `Location` column. This is because some workflows (e.g. `cumulus.wdl`) use file-type `Location` column in its sample sheet.