### PR TITLE
Redesign sample_manager

### DIFF
--- a/alto/utils/fastq_utils.py
+++ b/alto/utils/fastq_utils.py
@@ -1,20 +1,20 @@
 import glob
-from typing import List, Optional
+from typing import List, Optional, Dict
 
 from alto.utils import run_command
 
 
 class sample_manager:
     def __init__(self):
-        self.samples = set()
+        self.sample_map = dict()
 
-    def update_samples(self, sample_name: str):
-        if sample_name in self.samples:
+    def update_sample_map(self, sample_name: str, file_list: List[str] = None):
+        if sample_name in self.sample_map.keys():
             raise ValueError(f"{sample_name} is duplicated!")
-        self.samples.add(sample_name)
+        self.sample_map[sample_name] = file_list if file_list is not None else ["*"]
 
-    def get_samples(self) -> List[str]:
-        return list(self.samples)
+    def get_sample_map(self) -> Dict[str, List[str]]:
+        return self.sample_map
 
 
 def path_is_fastq(path: str) -> bool:
@@ -26,13 +26,42 @@ def transfer_fastq(
     source: str,
     dest: str,
     backend: str,
-    samples: List[str],
+    sample_map: Dict[str, List[str]],
     dry_run: bool,
     profile: Optional[str] = None,
     verbose: bool = True,
 ) -> None:
-    for sample in samples:
-        if len(glob.glob(f"{source}/{sample}_*.fastq.gz")) > 0:
+    for sample, path_list in sample_map.items():
+        if path_list == ["*"]:
+            # Copy all FASTQ files
+            if len(glob.glob(f"{source}/{sample}_*.fastq.gz")) > 0:
+                strato_cmd = [
+                    "strato",
+                    "cp",
+                    "--backend",
+                    backend,
+                    "--ionice",
+                    "-m",
+                    "--quiet",
+                    f"{source}/{sample}_*.fastq.gz",
+                    dest + "/",
+                ]
+            elif len(glob.glob(f"{source}/{sample}/{sample}_*.fastq.gz")) > 0:
+                strato_cmd = [
+                    "strato",
+                    "sync",
+                    "--backend",
+                    backend,
+                    "--ionice",
+                    "-m",
+                    "--quiet",
+                    f"{source}/{sample}",
+                    f"{dest}/{sample}",
+                ]
+            else:
+                raise ValueError(f"'{sample}' doesn't have any corresponding FASTQ file!")
+        else:
+            # Copy specific files
             strato_cmd = [
                 "strato",
                 "cp",
@@ -41,23 +70,9 @@ def transfer_fastq(
                 "--ionice",
                 "-m",
                 "--quiet",
-                f"{source}/{sample}_*.fastq.gz",
-                dest + "/",
             ]
-        elif len(glob.glob(f"{source}/{sample}/{sample}_*.fastq.gz")) > 0:
-            strato_cmd = [
-                "strato",
-                "sync",
-                "--backend",
-                backend,
-                "--ionice",
-                "-m",
-                "--quiet",
-                f"{source}/{sample}",
-                f"{dest}/{sample}",
-            ]
-        else:
-            raise ValueError(f"'{sample}' doesn't have any corresponding FASTQ file!")
+            strato_cmd.extend(path_list)
+            strato_cmd.append(dest + "/")
 
         if profile is not None:
             strato_cmd.extend(["--profile", profile])

--- a/alto/utils/fastq_utils.py
+++ b/alto/utils/fastq_utils.py
@@ -1,5 +1,5 @@
 import glob
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 from alto.utils import run_command
 

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -116,7 +116,7 @@ def transfer_data(
                 source=source,
                 dest=dest,
                 backend=backend,
-                samples=flowcell.manager.get_samples(),
+                sample_map=flowcell.manager.get_sample_map(),
                 dry_run=dry_run,
                 profile=profile,
                 verbose=verbose,
@@ -236,7 +236,7 @@ def transfer_sample_sheet(
             if flowcell.type == "bcl":
                 flowcell.manager.update_lanes(row["lane"] if "lane" in row else "*")
             else:
-                flowcell.manager.update_samples(row[sample_keyword])
+                flowcell.manager.update_sample_map(row[sample_keyword])
 
     for idxr, row in df[1:].iterrows():
         for idxc, value in row.iteritems():


### PR DESCRIPTION
Now `sample_manager` takes a dictionary/map instead of a list.

This is to allow upload a specific list of files for one sample, rather than all its FASTQ files:
* If `file_list` is given, update 
```python
sample_manager.sample_map[sample_name] = file_list
```
* Otherwise, update as follows to indicate all FASTQ files belonging to this sample.
```python
sample_manager.sample_map[sample_name] = ["*"]
```