### PR TITLE
iteritems is deprecated in Pandas v1.5.0

### DIFF
--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -239,7 +239,7 @@ def transfer_sample_sheet(
                 flowcell.manager.update_sample_map(row[sample_keyword])
 
     for idxr, row in df[1:].iterrows():
-        for idxc, value in row.iteritems():
+        for idxc, value in row.items():
             if isinstance(value, str) and os.path.exists(value):
                 source = os.path.abspath(value)
                 sub_url = input_file_to_output_url.get(source, None)


### PR DESCRIPTION
```
<stdin>:2: FutureWarning: iteritems is deprecated and will be removed in a future version. Use .items instead.
```