### PR TITLE
Fix issue when uploading tsv format sample sheet without headers

### DIFF
--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -238,7 +238,7 @@ def transfer_sample_sheet(
             else:
                 flowcell.manager.update_sample_map(row[sample_keyword])
 
-    for idxr, row in (df[1:].iterrows() if input_ext != ".tsv" else df.iterrows()):
+    for idxr, row in df[1:].iterrows() if input_ext != ".tsv" else df.iterrows():
         for idxc, value in row.items():
             if isinstance(value, str) and os.path.exists(value):
                 source = os.path.abspath(value)

--- a/alto/utils/io_utils.py
+++ b/alto/utils/io_utils.py
@@ -238,7 +238,7 @@ def transfer_sample_sheet(
             else:
                 flowcell.manager.update_sample_map(row[sample_keyword])
 
-    for idxr, row in df[1:].iterrows():
+    for idxr, row in (df[1:].iterrows() if input_ext != ".tsv" else df.iterrows()):
         for idxc, value in row.items():
             if isinstance(value, str) and os.path.exists(value):
                 source = os.path.abspath(value)


### PR DESCRIPTION
Cumulus workflows only consider two types of input sample sheet:
* CSV format with header row;
* TSV format without header row, which can be directly processed by WDL's `read_tsv` function.

For the second type, when uploading the sample sheet via `transfer_sample_sheet` function, the first row also needs to be considered.